### PR TITLE
Fix panic when running --local on Apple M1

### DIFF
--- a/internal/config/arch.go
+++ b/internal/config/arch.go
@@ -152,6 +152,7 @@ func Apple() *Arch {
 		Symbol:    regexp.MustCompile(`^\w+\s+<\w+>:$`),
 		Data:      regexp.MustCompile(`^\w+:\s+\w+\s+.+$`),
 		Comment:   regexp.MustCompile(`^\s*;.*$`),
+		Const:     regexp.MustCompile(`^not_implemented$`),
 		Registers: []string{"R0", "R1", "R2", "R3"},
 		BuildTags: "//go:build !noasm && darwin && arm64\n",
 		CommentCh: ";",


### PR DESCRIPTION
Running the example on M1 was causing a panic because of uninitialized regex